### PR TITLE
ET-OPS-4285

### DIFF
--- a/app/timetopayarrangement/des/model/DesDebit.scala
+++ b/app/timetopayarrangement/des/model/DesDebit.scala
@@ -20,7 +20,7 @@ import java.time.LocalDate
 
 import play.api.libs.json.{Json, OFormat}
 
-case class DesDebit(debitType: String, dueDate: LocalDate)
+case class DesDebit(debitType: String, dueDate: Option[LocalDate])
 
 object DesDebit {
   implicit val format: OFormat[DesDebit] = Json.format[DesDebit]

--- a/app/timetopaytaxpayer/des/model/DesDebit.scala
+++ b/app/timetopaytaxpayer/des/model/DesDebit.scala
@@ -24,12 +24,12 @@ import timetopaytaxpayer.cor.model.{Debit, Interest}
 final case class DesDebit(
     taxYearEnd:       LocalDate,
     charge:           DesCharge,
-    relevantDueDate:  LocalDate,
+    relevantDueDate:  Option[LocalDate],
     totalOutstanding: BigDecimal,
     interest:         Option[Interest]
 ) {
 
-  def asDebit() = Debit(
+  def asDebit(): Debit = Debit(
     originCode = this.charge.originCode,
     amount     = this.totalOutstanding,
     dueDate    = this.relevantDueDate,

--- a/cor/src/main/scala/timetopaytaxpayer/cor/model/Debit.scala
+++ b/cor/src/main/scala/timetopaytaxpayer/cor/model/Debit.scala
@@ -23,10 +23,14 @@ import play.api.libs.json.{Json, OFormat}
 final case class Debit(
     originCode: String,
     amount:     BigDecimal,
-    dueDate:    LocalDate,
+    dueDate:    Option[LocalDate],
     interest:   Option[Interest],
     taxYearEnd: LocalDate
-)
+) {
+  def getDueDate(): LocalDate = {
+    dueDate.getOrElse(throw new RuntimeException("Tried to process debit dueDate but wasn't present- should be blocked in EligibilityService"))
+  }
+}
 
 object Debit {
   implicit val format: OFormat[Debit] = Json.format[Debit]

--- a/test/support/TdAll.scala
+++ b/test/support/TdAll.scala
@@ -50,14 +50,14 @@ object TdAll {
       Debit(
         originCode = "IN1",
         amount     = 2500,
-        dueDate    = "2019-02-25",
+        dueDate    = Some("2019-02-25"),
         interest   = None,
         taxYearEnd = "2019-04-05"
       ),
       Debit(
         originCode = "IN2",
         amount     = 2500,
-        dueDate    = "2019-02-25",
+        dueDate    = Some("2019-02-25"),
         interest   = None,
         taxYearEnd = "2019-04-05"
       )

--- a/test/timetopaytaxpayer/TaxpayerControllerSpec.scala
+++ b/test/timetopaytaxpayer/TaxpayerControllerSpec.scala
@@ -41,7 +41,7 @@ class TaxpayerControllerSpec extends ItSpec {
       CommunicationPreferences(
         welshLanguageIndicator = true, audioIndicator = false, largePrintIndicator = false, brailleIndicator = false
       ),
-      Seq(Debit("IN1", 2500, date20190225, None, date20190405), Debit("IN2", 2500, date20190225, None, date20190405)),
+      Seq(Debit("IN1", 2500, Some(date20190225), None, date20190405), Debit("IN2", 2500, Some(date20190225), None, date20190405)),
       Seq(
         Return(date20190405, None, Some(date20190131), None),
         Return(

--- a/test/timetopaytaxpayer/cor/model/TaxpayerJsonSpec.scala
+++ b/test/timetopaytaxpayer/cor/model/TaxpayerJsonSpec.scala
@@ -36,7 +36,8 @@ class TaxpayerJsonSpec extends WordSpec with Matchers {
       val debits =
         List(
           Debit(
-            originCode = "POA2", amount = 250.52, dueDate = LocalDate.of(2016, 1, 31),
+            originCode = "POA2", amount = 250.52,
+            dueDate    = Some(LocalDate.of(2016, 1, 31)),
             interest   = Some(Interest(Some(LocalDate.of(2016, 6, 1)), 42.32)),
             taxYearEnd = LocalDate.of(2017, 4, 5)
           )
@@ -150,7 +151,7 @@ class TaxpayerJsonSpec extends WordSpec with Matchers {
         Debit(
           originCode = "POA2",
           amount     = 250.52,
-          dueDate    = LocalDate.parse("2016-01-31"),
+          dueDate    = Some(LocalDate.parse("2016-01-31")),
           interest   = Some(Interest(Some(LocalDate.parse("2016-06-01")), 42.32)),
           taxYearEnd = LocalDate.parse("2017-04-05")
         )
@@ -205,7 +206,7 @@ class TaxpayerJsonSpec extends WordSpec with Matchers {
         Debit(
           originCode = "POA2",
           amount     = 250.52,
-          dueDate    = LocalDate.parse("2016-01-31"),
+          dueDate    = Some(LocalDate.parse("2016-01-31")),
           interest   = Some(Interest(Some(LocalDate.parse("2016-06-01")), 42.32)),
           taxYearEnd = LocalDate.parse("2017-04-05")
         )

--- a/test/uk/gov/hmrc/timetopaytaxpayer/debits/DesDebitsJsonSpec.scala
+++ b/test/uk/gov/hmrc/timetopaytaxpayer/debits/DesDebitsJsonSpec.scala
@@ -55,7 +55,7 @@ class DesDebitsJsonSpec extends WordSpecLike with Matchers {
           DesDebit(
             taxYearEnd       = LocalDate.of(2016, 4, 5),
             charge           = DesCharge(originCode   = "POA1", creationDate = LocalDate.of(2015, 11, 5)),
-            relevantDueDate  = LocalDate.of(2015, 11, 5),
+            relevantDueDate  = Some(LocalDate.of(2015, 11, 5)),
             totalOutstanding = 5000,
             interest         = Some(Interest(creationDate = Some(LocalDate.of(2015, 11, 5)), amount = 500))
           )
@@ -99,14 +99,14 @@ class DesDebitsJsonSpec extends WordSpecLike with Matchers {
           DesDebit(
             taxYearEnd       = LocalDate.of(2016, 4, 5),
             charge           = DesCharge(originCode   = "POA1", creationDate = LocalDate.of(2015, 11, 5)),
-            relevantDueDate  = LocalDate.of(2015, 11, 5),
+            relevantDueDate  = Some(LocalDate.of(2015, 11, 5)),
             totalOutstanding = 5000,
             interest         = Some(Interest(creationDate = None, amount = 500))
           ),
           DesDebit(
             taxYearEnd       = LocalDate.of(2016, 4, 5),
             charge           = DesCharge(originCode   = "POA1", creationDate = LocalDate.of(2015, 11, 5)),
-            relevantDueDate  = LocalDate.of(2015, 11, 5),
+            relevantDueDate  = Some(LocalDate.of(2015, 11, 5)),
             totalOutstanding = 5000,
             interest         = None
           )

--- a/test/uk/gov/hmrc/timetopaytaxpayer/taxpayer/DebitsAndReturnsSpec.scala
+++ b/test/uk/gov/hmrc/timetopaytaxpayer/taxpayer/DebitsAndReturnsSpec.scala
@@ -39,7 +39,7 @@ class DebitsAndReturnsSpec extends UnitSpec {
       Debit(
         originCode = "POA2",
         amount     = 250.52,
-        dueDate    = LocalDate.parse("2016-01-31"),
+        dueDate    = Some(LocalDate.parse("2016-01-31")),
         interest   = Some(Interest(Some(LocalDate.parse("2016-06-01")), 42.32)),
         taxYearEnd = LocalDate.parse("2017-04-05")
       )
@@ -83,7 +83,7 @@ class DebitsAndReturnsSpec extends UnitSpec {
       Debit(
         originCode = "POA2",
         amount     = 250.52,
-        dueDate    = LocalDate.parse("2016-01-31"),
+        dueDate    = Some(LocalDate.parse("2016-01-31")),
         interest   = Some(Interest(Some(LocalDate.parse("2016-06-01")), 42.32)),
         taxYearEnd = LocalDate.parse("2017-04-05")
       )


### PR DESCRIPTION
-Debit field dueDate now optional
- needs updated SSTTP frontend to run -> https://github.com/hmrc/self-service-time-to-pay-frontend/pull/462/
-https://jira.tools.tax.service.gov.uk/browse/OPS-4285